### PR TITLE
Fix feature/groundtruth loading bug

### DIFF
--- a/extract_features.m
+++ b/extract_features.m
@@ -9,7 +9,8 @@ end
     
 filename = 'features.mat';
 if (exist(filename, 'file') == 0)
-   save(filename); 
+    % create a new empty mat file
+    save(filename, '');  
 end
 
 for i = g_data_idxes
@@ -17,7 +18,9 @@ for i = g_data_idxes
     % check if the features exists
     features_i = sprintf('features%d', i);
     eval(sprintf('global %s', features_i));
-    if exist(features_i, 'var')  ~= 0
+
+    % check if the global variable has been defined(size != 0)
+    if size(eval(features_i), 2) ~= 0
         continue;
     end
         
@@ -26,7 +29,7 @@ for i = g_data_idxes
     [~,features] = fft_feature(ground_truth, sig);
     %features 3D: (window, channel, feature(frequency))
     eval(sprintf('features%d = features;', i));
-    fprintf(1,'save features%d\n', i); % display formatted string
+    %fprintf(1,'save features%d\n', i); % display formatted string
     save(filename,sprintf('features%d', i), '-append');
 end
 

--- a/get_data.m
+++ b/get_data.m
@@ -18,10 +18,10 @@ for f = 1 : files
         load(filename);
         if (strfind(filename, 'BPMtrace') > 0)  % ground truth
             ground_truth_o = BPM0;
-            disp(strcat('loaded ground truth:', num2str(data_idx)));
+            %disp(strcat('loaded ground truth:', num2str(data_idx)));
         else
             sig_o = sig;
-            disp(strcat('loaded sig:', num2str(data_idx)));
+            %disp(strcat('loaded sig:', num2str(data_idx)));
         end
     end
 end

--- a/save_groundtruths.m
+++ b/save_groundtruths.m
@@ -6,7 +6,8 @@ end
 
 filename = 'ground_truths.mat';
 if (exist(filename, 'file') == 0)
-   save(filename); 
+    % create a new empty mat file
+    save(filename, ''); 
 end
 
 for i = g_data_idxes
@@ -14,7 +15,9 @@ for i = g_data_idxes
     % check if the ground_truths exists
     gt_i = sprintf('ground_truth%d', i);
     eval(sprintf('global %s', gt_i));
-    if exist(gt_i, 'var')  ~= 0
+    
+    % check if the global variable has been defined(size != 0)
+    if size(eval(gt_i), 2) ~= 0
         continue;
     end
     


### PR DESCRIPTION
When no data was predefined, these functions gave null features and
groundtruths.
Changing the condition statement of checking global variable
predefinition to be checking the size of the var is good.
